### PR TITLE
Make change event handling less magical.

### DIFF
--- a/lib/store.js
+++ b/lib/store.js
@@ -35,25 +35,59 @@ util.inherits(Store, EventEmitter);
 Store.createStore = Store;
 
 /**
- * Defines a new property named `name` on the Store. If provided, `value` sets
- * the initial value of the property. No `"change"` event is fired for this
- * initial value.
+ * Gets the value of the `name` property on the store.
+ */
+Store.prototype.get = function get(name) {
+  return this._db[name];
+};
+
+/**
+ * Defines a property on the store, optionally with an initial value.
+ * Does not fire a change event.
  */
 Store.prototype.define = function define(name, value) {
-  if (!this.has(name)) {
-    this._defineProperty(name, value);
-  } else {
-    this[name] = value;
-  }
+  this._db[name] = value;
 
   return this;
+};
+
+/**
+ * Sets a new value for the `name` property on the store. Always fires a
+ * `"change"` event.
+ */
+Store.prototype.set = function set(name, value) {
+  var self = this;
+
+  self._db[name] = value;
+
+  process.nextTick(function () {
+    self.emit('change', self);
+    self.emit('change:' + name, value);
+  });
+
+  return self;
+};
+
+/**
+ * Passes the `name` property to `updateInPlace` in the expectation that
+ * it will modify it. Always fires a `"change"` event.
+ */
+Store.prototype.update = function update(name, updateInPlace) {
+  var self = this;
+
+  updateInPlace(this._db[name]);
+
+  process.nextTick(function () {
+    self.emit('change', self);
+    self.emit('change:' + name, self._db[name]);
+  });
 };
 
 /**
  * Returns true if the property has been defined on this Store, false otherwise.
  */
 Store.prototype.has = function has(name) {
-  return this.hasOwnProperty(name);
+  return this._db.hasOwnProperty(name);
 };
 
 /**
@@ -110,7 +144,7 @@ Store.prototype.fromObject = function fromObject(obj) {
   assert(typeof obj === 'object', 'Invalid object');
 
   Object.keys(obj).forEach(function (key) {
-    self.define(key, obj[key]);
+    self.set(key, obj[key]);
   });
 
   return self;
@@ -124,39 +158,9 @@ Store.prototype._init = function _init(properties) {
 
   if (properties && typeof properties === 'object') {
     Object.keys(properties).forEach(function (key) {
-      self.define(key, properties[key]);
+      self.set(key, properties[key]);
     });
   }
-
-  return self;
-};
-
-/**
- * Internal helper to define the underlying property.
- */
-Store.prototype._defineProperty = function _defineProperty(name, initialValue) {
-  var self = this;
-
-  Object.defineProperty(self, name, {
-    get: function () {
-      return self._db[name];
-    },
-    set: function (value) {
-      self._db[name] = value;
-
-      process.nextTick(function () {
-        self.emit('change', self);
-        self.emit('change:' + name, value);
-      });
-
-      return value;
-    }
-  });
-
-  // Synchronously fire initial change events.
-  self._db[name] = initialValue;
-  self.emit('change', self);
-  self.emit('change:' + name, initialValue);
 
   return self;
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "littlest-dispatcher",
-  "version": "0.2.5",
+  "version": "0.3.0",
   "description": "An attempt at an async-friendly, isomorphic Flux dispatcher with as little internal code as possible.",
   "main": "lib/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "littlest-dispatcher",
-  "version": "0.3.0",
+  "version": "0.2.5",
   "description": "An attempt at an async-friendly, isomorphic Flux dispatcher with as little internal code as possible.",
   "main": "lib/index.js",
   "scripts": {

--- a/test/integration.js
+++ b/test/integration.js
@@ -10,14 +10,14 @@ describe('Integration', function () {
     var store = dispatcher.createStore()
       .define('state', 'splash')
       .handle('navigate:succeeded', function (state) {
-        this.state = state;
+        this.set('state', state);
       });
 
-    expect(store.state).to.equal('splash');
+    expect(store.get('state')).to.equal('splash');
 
     store.on('change:state', function (state) {
       expect(state).to.equal('login');
-      expect(store.state).to.equal('login');
+      expect(store.get('state')).to.equal('login');
       done();
     });
 


### PR DESCRIPTION
Here's a first pass at implementing the `get`, `set`, `update` methods for more controlled change event handling. Care to look it over and provide feedback? I have compatible changes to Firkintun on my local box that I can push to a fork if you'd like to glance at those as well.

I opted to keep the `define` method since it seems useful to have a method for defining a property when very first creating the store that doesn't generate a change event.
